### PR TITLE
Add theme options label customization

### DIFF
--- a/components/settings/ThemeOptions.vue
+++ b/components/settings/ThemeOptions.vue
@@ -12,11 +12,11 @@
 			</li>
 		</ul>
 		<div v-if="!yuu.disableDarkTheme" class="dark-theme-options toggle-option">
-			<label for="dark-theme-toggle">{{ yuu.optionLabelDarkTheme }}</label>
+			<label for="dark-theme-toggle">{{ yuu.labels.darkTheme }}</label>
 			<input id="dark-theme-toggle" v-model="darkTheme" type="checkbox" @change="toggleDarkTheme" />
 		</div>
 		<div v-if="yuu.hasThemes && !yuu.disableThemeIgnore" class="force-theme-options toggle-option">
-			<label for="force-theme-toggle">{{ yuu.optionLabelIgnore }}</label>
+			<label for="force-theme-toggle">{{ yuu.labels.forcedThemes }}</label>
 			<input id="force-theme-toggle" v-model="ignoreForcedThemes" type="checkbox" @change="toggleForcedThemes" />
 		</div>
 		<div v-if="yuu.extraOptions && yuu.extraOptions.below" class="user-options-below">

--- a/components/settings/ThemeOptions.vue
+++ b/components/settings/ThemeOptions.vue
@@ -12,11 +12,11 @@
 			</li>
 		</ul>
 		<div v-if="!yuu.disableDarkTheme" class="dark-theme-options toggle-option">
-			<label for="dark-theme-toggle">Enable Dark Theme?</label>
+			<label for="dark-theme-toggle">{{ yuu.optionLabelDarkTheme }}</label>
 			<input id="dark-theme-toggle" v-model="darkTheme" type="checkbox" @change="toggleDarkTheme" />
 		</div>
 		<div v-if="yuu.hasThemes && !yuu.disableThemeIgnore" class="force-theme-options toggle-option">
-			<label for="force-theme-toggle">Ignore Forced Themes?</label>
+			<label for="force-theme-toggle">{{ yuu.optionLabelIgnore }}</label>
 			<input id="force-theme-toggle" v-model="ignoreForcedThemes" type="checkbox" @change="toggleForcedThemes" />
 		</div>
 		<div v-if="yuu.extraOptions && yuu.extraOptions.below" class="user-options-below">

--- a/mixins/yuuConfig.js
+++ b/mixins/yuuConfig.js
@@ -15,8 +15,10 @@ export default {
 			disableDarkTheme: yuu.disableDarkTheme || false,
 			disableThemeIgnore: yuu.disableThemeIgnore || false,
 			extraOptions: yuu.extraOptions || {},
-			optionLabelDarkTheme: yuu.optionLabelDarkTheme || "Enable Dark Theme?",
-			optionLabelIgnore: yuu.optionLabelIgnore || "Ignore Forced Themes?",
+			labels: yuu.labels || {
+				darkTheme: "Enable Dark Theme?",
+				forcedThemes: "Ignore Forced Themes?",
+			},
 		};
 
 		this.yuu.hasThemes = Array.isArray(this.yuu.themes) && this.yuu.themes.length > 0;

--- a/mixins/yuuConfig.js
+++ b/mixins/yuuConfig.js
@@ -5,8 +5,9 @@ export default {
 		};
 	},
 
-	mounted() {
+	beforeMount() {
 		const { yuu = {} } = this.$site.themeConfig;
+		const { labels = {} } = yuu;
 
 		this.yuu = {
 			themes: yuu.colorThemes || ['blue', 'red', 'purple'],
@@ -15,9 +16,9 @@ export default {
 			disableDarkTheme: yuu.disableDarkTheme || false,
 			disableThemeIgnore: yuu.disableThemeIgnore || false,
 			extraOptions: yuu.extraOptions || {},
-			labels: yuu.labels || {
-				darkTheme: "Enable Dark Theme?",
-				forcedThemes: "Ignore Forced Themes?",
+			labels: {
+				darkTheme: labels.darkTheme || "Enable Dark Theme?",
+				forcedThemes: labels.forcedThemes || "Ignore Forced Themes?",
 			},
 		};
 

--- a/mixins/yuuConfig.js
+++ b/mixins/yuuConfig.js
@@ -15,6 +15,8 @@ export default {
 			disableDarkTheme: yuu.disableDarkTheme || false,
 			disableThemeIgnore: yuu.disableThemeIgnore || false,
 			extraOptions: yuu.extraOptions || {},
+			optionLabelDarkTheme: yuu.optionLabelDarkTheme || "Enable Dark Theme?",
+			optionLabelIgnore: yuu.optionLabelIgnore || "Ignore Forced Themes?",
 		};
 
 		this.yuu.hasThemes = Array.isArray(this.yuu.themes) && this.yuu.themes.length > 0;


### PR DESCRIPTION
Related to #18 

This PR adds two new configuration entries:
- `labels.darkTheme`: the label shown in the Theme settings for the dark theme toggle
- `labels.forcedThemes`: the label shown in the Theme settings for the ignore forced theme toggle